### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,8 +3,8 @@
 	<prefix>html5</prefix>
 	<icon>html5.png</icon>
 
-	<version>1.0.1</version>
-	<etat>dev</etat>
+	<version>1.0.2</version>
+	<etat>test</etat>
 	<categorie>outil</categorie>
 
 	<slogan>Améliorer l'usage de HTML5 dans SPIP</slogan>
@@ -14,7 +14,7 @@
 -* correction des erreurs résiduelles dans le code généré,
 -* sans oublier d'activer HTML5 dans SPIP.
 	</description>
-	<lien>https://contrib.spip.net/html5</lien>
+	<lien>https://contrib.spip.net/5145</lien>
 
 	<auteur>davux, [tetue->http://spip.tetue.net]</auteur>
 	<licence>GNU/GPL, WTFPL</licence>


### PR DESCRIPTION
- Url de documentation sur contrib par numéro d'article, pour ne pas dépendre de l'url propre (et aussi, faciliter l'ajout automatique du doc distant)
- passage en test dans la mesure où on propose un article de doc